### PR TITLE
Auto-assign full-screen space names based on app name

### DIFF
--- a/Spaceman/Helpers/SpaceObserver.swift
+++ b/Spaceman/Helpers/SpaceObserver.swift
@@ -63,9 +63,18 @@ class SpaceObserver {
                                   isCurrentSpace: isCurrentSpace,
                                   isFullScreen: isFullScreen)
                 
-                if let data = defaults.value(forKey:"spaceNames") as? Data {
-                    let dict = try! PropertyListDecoder().decode(Dictionary<String, SpaceNameInfo>.self, from: data)
-                    space.spaceName = dict[spaceID] != nil ? dict[spaceID]!.spaceName : isFullScreen ? "FUL" : "N/A"
+                if let data = defaults.value(forKey:"spaceNames") as? Data,
+                   let dict = try? PropertyListDecoder().decode(Dictionary<String, SpaceNameInfo>.self, from: data),
+                   let saved = dict[spaceID] {
+                    space.spaceName = saved.spaceName
+                } else if isFullScreen {
+                    if let pid = s["pid"] as? pid_t,
+                       let app = NSRunningApplication(processIdentifier: pid),
+                       let name = app.localizedName {
+                        space.spaceName = name.prefix(3).uppercased()
+                    } else {
+                        space.spaceName = "FUL"
+                    }
                 }
                 
                 let nameInfo = SpaceNameInfo(spaceNum: spaceNumber, spaceName: space.spaceName)


### PR DESCRIPTION
This might be a matter of personal preference, but I've found that especially in cases where a user has multiple full-screen apps, the default full-screen space name "FUL" can be a little unclear. This pull request automatically detects the names of full-screen applications and uses the first three letters of the name as the default name of a full-screen app's space.