### PR TITLE
New feature: option to show desktop numbers with rectangles

### DIFF
--- a/Spaceman/Helpers/IconCreator.swift
+++ b/Spaceman/Helpers/IconCreator.swift
@@ -39,8 +39,10 @@ class IconCreator {
         switch spacemanStyle {
         case .numbers:
             icons = createNumberedIcons(spaces)
-        case .both:
-            icons = createRectWithNumbersIcons(icons, spaces)
+        case .numbersAndRects:
+            icons = createRectWithNumbersIcons(icons, spaces, desktopsOnly: false)
+        case .desktopNumbersAndRects:
+            icons = createRectWithNumbersIcons(icons, spaces, desktopsOnly: true)
         case .text:
             iconSize.width = 49
             icons = createNamedIcons(icons, spaces)
@@ -74,21 +76,24 @@ class IconCreator {
         return newIcons
     }
     
-    private func createRectWithNumbersIcons(_ icons: [NSImage], _ spaces: [Space]) -> [NSImage] {
+    private func createRectWithNumbersIcons(_ icons: [NSImage], _ spaces: [Space], desktopsOnly: Bool) -> [NSImage] {
         var index = 0
         var newIcons = [NSImage]()
         
         for s in spaces {
             let textRect = NSRect(origin: CGPoint.zero, size: iconSize)
-            let spaceNumber = NSString(string: String(s.spaceNumber))
+            let number = desktopsOnly ? s.desktopNumber : s.spaceNumber
             let iconImage = NSImage(size: iconSize)
             let numberImage = NSImage(size: iconSize)
-            
-            numberImage.lockFocus()
-            spaceNumber.drawVerticallyCentered(
-                in: textRect,
-                withAttributes: getStringAttributes(alpha: 1))
-            numberImage.unlockFocus()
+
+            if (number != nil) {
+                numberImage.lockFocus()
+                let spaceNumber = NSString(string: String(number!))
+                spaceNumber.drawVerticallyCentered(
+                    in: textRect,
+                    withAttributes: getStringAttributes(alpha: 1))
+                numberImage.unlockFocus()
+            }
             
             iconImage.lockFocus()
             icons[index].draw(

--- a/Spaceman/Helpers/SpaceObserver.swift
+++ b/Spaceman/Helpers/SpaceObserver.swift
@@ -50,16 +50,24 @@ class SpaceObserver {
                 }
                 return
             }
-            
+
+            var lastDesktopNumber = 0
+
             for s in spaces {
                 let spaceID = String(s["ManagedSpaceID"] as! Int)
                 let spaceNumber: Int = spacesIndex + 1
                 let isCurrentSpace = activeSpaceID == s["ManagedSpaceID"] as! Int
                 let isFullScreen = s["TileLayoutManager"] as? [String: Any] != nil
+                var desktopNumber : Int?
+                if !isFullScreen {
+                    lastDesktopNumber += 1
+                    desktopNumber = lastDesktopNumber
+                }
                 var space = Space(displayID: displayID,
                                   spaceID: spaceID,
                                   spaceName: "N/A",
                                   spaceNumber: spaceNumber,
+                                  desktopNumber: desktopNumber,
                                   isCurrentSpace: isCurrentSpace,
                                   isFullScreen: isFullScreen)
                 

--- a/Spaceman/Model/Space.swift
+++ b/Spaceman/Model/Space.swift
@@ -12,6 +12,7 @@ struct Space {
     var spaceID: String
     var spaceName: String
     var spaceNumber: Int
+    var desktopNumber: Int?
     var isCurrentSpace: Bool
     var isFullScreen: Bool
 }

--- a/Spaceman/Model/SpacemanStyle.swift
+++ b/Spaceman/Model/SpacemanStyle.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum SpacemanStyle: Int {
-    case none, numbers, both, text
+    case none, numbers, numbersAndRects, desktopNumbersAndRects, text
 }

--- a/Spaceman/View/PreferencesView.swift
+++ b/Spaceman/View/PreferencesView.swift
@@ -133,7 +133,7 @@ struct PreferencesView: View {
                     .fontWeight(.semibold)
 //                Toggle("Use single icon indicator", isOn: .constant(false)) // TODO: Implement this
                 spacesStylePicker
-                spaceNameEditor.disabled(selectedStyle != 3 ? true : false)
+                spaceNameEditor.disabled(selectedStyle != SpacemanStyle.text.rawValue ? true : false)
             }
             .padding()
             
@@ -152,10 +152,11 @@ struct PreferencesView: View {
     // MARK: - Style Picker
     private var spacesStylePicker: some View {
         Picker(selection: $selectedStyle, label: Text("Style")) {
-            Text("Rectangles").tag(0)
-            Text("Numbers").tag(1)
-            Text("Rectangles with numbers").tag(2)
-            Text("Named spaces").tag(3)
+            Text("Rectangles").tag(SpacemanStyle.none.rawValue)
+            Text("Numbers").tag(SpacemanStyle.numbers.rawValue)
+            Text("Rectangles with numbers").tag(SpacemanStyle.numbersAndRects.rawValue)
+            Text("Rectangles with desktop numbers").tag(SpacemanStyle.desktopNumbersAndRects.rawValue)
+            Text("Named spaces").tag(SpacemanStyle.text.rawValue)
         }
         .onChange(of: selectedStyle) { val in
             selectedStyle = val


### PR DESCRIPTION
User story:

As a user who uses multiple desktops and full-screen apps,
I want to have an option to see numbers for desktops only, while seeing full screen apps as just rectangles,
So that I can distinguish between desktops and full-screen apps easier, AND use ^+number shortcuts more intuitively by seeing the desktop number

<img width="153" alt="image" src="https://user-images.githubusercontent.com/8123567/178894543-3e2341fa-a8b8-4123-b49a-d00f91d929f8.png">

<img width="403" alt="image" src="https://user-images.githubusercontent.com/8123567/178894593-f096506b-00d4-41a1-9921-c2048bd114cb.png">
