### PR TITLE
fix: retain managed display spaces

### DIFF
--- a/Spaceman/Helpers/SpaceObserver.swift
+++ b/Spaceman/Helpers/SpaceObserver.swift
@@ -28,7 +28,7 @@ class SpaceObserver {
     }
     
     @objc public func updateSpaceInformation() {
-        let displays = CGSCopyManagedDisplaySpaces(conn) as! [NSDictionary]
+        let displays = CGSCopyManagedDisplaySpaces(conn)!.takeRetainedValue() as! [NSDictionary]
         var activeSpaceID = -1
         var spacesIndex = 0
         var allSpaces = [Space]()

--- a/Spaceman/Spaceman-Bridging-Header.h
+++ b/Spaceman/Spaceman-Bridging-Header.h
@@ -11,7 +11,7 @@
 #import <Foundation/Foundation.h>
 
 int _CGSDefaultConnection();
-id CGSCopyManagedDisplaySpaces(int conn);
+CFArrayRef CGSCopyManagedDisplaySpaces(int conn);
 id CGSCopyActiveMenuBarDisplayIdentifier(int conn);
 
 #endif /* Spaceman_Bridging_Header_h */


### PR DESCRIPTION
This fixes a memory leak. CGSCopyManagedDisplaySpaces returns an unmanaged object reference, so we need to retain it to ensure it's properly cleaned up.

Before:

<img width="1905" alt="Screenshot 2023-05-31 at 18 40 09" src="https://github.com/Jaysce/Spaceman/assets/722385/bba8b018-9eec-4019-b678-eb647e98d7aa">

After:

<img width="1915" alt="Screenshot 2023-05-31 at 18 53 45" src="https://github.com/Jaysce/Spaceman/assets/722385/4b50d9c1-ef0b-4c9c-9956-30da74c0dd88">