### PR TITLE
 feature: "Only show active spaces"

### DIFF
--- a/Spaceman/Helpers/IconCreator.swift
+++ b/Spaceman/Helpers/IconCreator.swift
@@ -166,7 +166,7 @@ class IconCreator {
             
             var nextSpaceIsOnDifferentDisplay = false
             
-            if index + 1 < spaces.count {
+            if !shouldBypassInactiveSpaces && index + 1 < spaces.count {
                 let thisDispID = spaces[index + 1].displayID
                 if thisDispID != currentDisplayID {
                     currentDisplayID = thisDispID

--- a/Spaceman/Helpers/IconCreator.swift
+++ b/Spaceman/Helpers/IconCreator.swift
@@ -158,7 +158,12 @@ class IconCreator {
         var currentDisplayID = spaces[0].displayID
         displayCount = 1
         
+        let shouldBypassInactiveSpaces = defaults.bool(forKey: "hideInactiveSpaces")
         for index in 0 ..< spaces.count {
+            if shouldBypassInactiveSpaces && !spaces[index].isCurrentSpace {
+                continue
+            }
+            
             var nextSpaceIsOnDifferentDisplay = false
             
             if index + 1 < spaces.count {

--- a/Spaceman/View/PreferencesView.swift
+++ b/Spaceman/View/PreferencesView.swift
@@ -111,8 +111,6 @@ struct PreferencesView: View {
                     .fontWeight(.semibold)
                 LaunchAtLogin.Toggle(){Text("Launch Spaceman at login")}
                 Toggle("Refresh spaces in background", isOn: $autoRefreshSpaces)
-                Toggle("Only show active spaces", isOn: $hideInactiveSpaces)
-                    .disabled(selectedStyle == 0) // Rectangles style
                 shortcutRecorder.disabled(autoRefreshSpaces ? true : false)
             }
             .padding()
@@ -126,9 +124,6 @@ struct PreferencesView: View {
                     KeyboardShortcuts.enable(.refresh)
                 }
             }
-            .onChange(of: hideInactiveSpaces) { _ in
-                NotificationCenter.default.post(name: NSNotification.Name(rawValue: "ButtonPressed"), object: nil)
-            }
             
             Divider()
             
@@ -140,9 +135,15 @@ struct PreferencesView: View {
 //                Toggle("Use single icon indicator", isOn: .constant(false)) // TODO: Implement this
                 spacesStylePicker
                 spaceNameEditor.disabled(selectedStyle != SpacemanStyle.text.rawValue ? true : false)
+                
+                Toggle("Only show active spaces", isOn: $hideInactiveSpaces)
+                    .disabled(selectedStyle == 0) // Rectangles style
             }
             .padding()
-            
+            .onChange(of: hideInactiveSpaces) { _ in
+                NotificationCenter.default.post(name: NSNotification.Name(rawValue: "ButtonPressed"), object: nil)
+            }
+
         }
     }
     
@@ -157,6 +158,7 @@ struct PreferencesView: View {
     
     // MARK: - Style Picker
     private var spacesStylePicker: some View {
+        
         Picker(selection: $selectedStyle, label: Text("Style")) {
             Text("Rectangles").tag(SpacemanStyle.none.rawValue)
             Text("Numbers").tag(SpacemanStyle.numbers.rawValue)

--- a/Spaceman/View/PreferencesView.swift
+++ b/Spaceman/View/PreferencesView.swift
@@ -16,6 +16,7 @@ struct PreferencesView: View {
     @AppStorage("displayStyle") private var selectedStyle = 0
     @AppStorage("spaceNames") private var data = Data()
     @AppStorage("autoRefreshSpaces") private var autoRefreshSpaces = false
+    @AppStorage("hideInactiveSpaces") private var hideInactiveSpaces = false
     @StateObject private var prefsVM = PreferencesViewModel()
     
     // MARK: - Main Body
@@ -110,6 +111,8 @@ struct PreferencesView: View {
                     .fontWeight(.semibold)
                 LaunchAtLogin.Toggle(){Text("Launch Spaceman at login")}
                 Toggle("Refresh spaces in background", isOn: $autoRefreshSpaces)
+                Toggle("Only show active spaces", isOn: $hideInactiveSpaces)
+                    .disabled(selectedStyle == 0) // Rectangles style
                 shortcutRecorder.disabled(autoRefreshSpaces ? true : false)
             }
             .padding()
@@ -122,6 +125,9 @@ struct PreferencesView: View {
                     prefsVM.pauseTimer()
                     KeyboardShortcuts.enable(.refresh)
                 }
+            }
+            .onChange(of: hideInactiveSpaces) { _ in
+                NotificationCenter.default.post(name: NSNotification.Name(rawValue: "ButtonPressed"), object: nil)
             }
             
             Divider()
@@ -159,6 +165,10 @@ struct PreferencesView: View {
             Text("Named spaces").tag(SpacemanStyle.text.rawValue)
         }
         .onChange(of: selectedStyle) { val in
+            if val == 0 { // Rectangles style
+                hideInactiveSpaces = false
+            }
+            
             selectedStyle = val
             NotificationCenter.default.post(name: NSNotification.Name(rawValue: "ButtonPressed"), object: nil)
         }

--- a/Spaceman/View/PreferencesWindow.swift
+++ b/Spaceman/View/PreferencesWindow.swift
@@ -11,7 +11,7 @@ import AppKit
 class PreferencesWindow: NSWindow {
     init() {
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 314),
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 330),
             styleMask: [.titled, .fullSizeContentView],
             backing: .buffered,
             defer: false


### PR DESCRIPTION
Implemented "Only show active spaces" as a option in preferences which will hide all non-active space numbers from showing on the menubar display.

This button gets auto-disabled when the "Rectangles" style is selected since it would just end up showing a singular rectangle for each monitor that does not convey any information.

I primarily wrote this change since the notch on Apple Silicon iterations of the MacBook Pro means that there is very limited menu bar icon real estate that the inactive desktop numbers/icons would potentially completely cover if they can even fit on the menu bar in the first place (in the case of having many virtual desktops open).

This PR would address #14, #23

## Screenshots

_Note: the virtual desktop configuration I have in these screenshots is 9 virtual desktops on the left monitor and one on the right monitor. In addition to this, I have the JankyBorders app active so ignore the blue border around the preference window._

### Previous behavior (disabling newly-added checkbox "Only show active spaces")

![Screenshot 2024-03-15 at 9 55 58 PM](https://github.com/Jaysce/Spaceman/assets/31578557/d12927f3-e25d-452f-9838-d6e32df0cb47)


### New behavior

![Screenshot 2024-03-15 at 9 56 01 PM](https://github.com/Jaysce/Spaceman/assets/31578557/a6c90683-1697-4057-9788-f547ea068d2f)


### Disabled when "Rectangles" style is chosen

![Screenshot 2024-03-15 at 9 56 08 PM](https://github.com/Jaysce/Spaceman/assets/31578557/4485af23-624c-481b-beae-4b6ac6fee2db)