### PR TITLE
feat: support longer space names with dynamic icon widths and improved contrast

### DIFF
--- a/Spaceman/Helpers/IconCreator.swift
+++ b/Spaceman/Helpers/IconCreator.swift
@@ -44,7 +44,6 @@ class IconCreator {
         case .desktopNumbersAndRects:
             icons = createRectWithNumbersIcons(icons, spaces, desktopsOnly: true)
         case .text:
-            iconSize.width = 49
             icons = createNamedIcons(icons, spaces)
         default:
             break
@@ -117,37 +116,58 @@ class IconCreator {
     }
 
     private func createNamedIcons(_ icons: [NSImage], _ spaces: [Space]) -> [NSImage] {
-        var index = 0
         var newIcons = [NSImage]()
+        let padding = CGFloat(12)
+        let cornerRadius = CGFloat(3)
 
         for space in spaces {
-            let textRect = NSRect(origin: CGPoint.zero, size: iconSize)
             let spaceText = NSString(string: "\(space.spaceNumber): \(space.spaceName.uppercased())")
-            let iconImage = NSImage(size: iconSize)
-            let textImage = NSImage(size: iconSize)
+            let isActive = space.isCurrentSpace
 
-            textImage.lockFocus()
-            spaceText.drawVerticallyCentered(
-                in: textRect,
-                withAttributes: getStringAttributes(alpha: 1))
-            textImage.unlockFocus()
+            let textAttrs = getStringAttributes(alpha: 1, fontSize: 10)
+            let textSize = spaceText.size(withAttributes: textAttrs)
+            let dynamicWidth = max(textSize.width + padding, 49)
+            let dynamicSize = NSSize(width: dynamicWidth, height: iconSize.height)
+            let iconImage = NSImage(size: dynamicSize)
 
             iconImage.lockFocus()
-            icons[index].draw(
-                in: textRect,
-                from: NSRect.zero,
-                operation: NSCompositingOperation.sourceOver,
-                fraction: 1.0)
-            textImage.draw(
-                in: textRect,
-                from: NSRect.zero,
-                operation: NSCompositingOperation.destinationOut,
-                fraction: 1.0)
+
+            let bgRect = NSRect(origin: CGPoint.zero, size: dynamicSize)
+            let bgPath = NSBezierPath(roundedRect: bgRect.insetBy(dx: 1, dy: 0.5), xRadius: cornerRadius, yRadius: cornerRadius)
+
+            if isActive {
+                // Active: filled background, text cut out via destinationOut
+                NSColor.black.setFill()
+                bgPath.fill()
+
+                let textImage = NSImage(size: dynamicSize)
+                textImage.lockFocus()
+                spaceText.drawVerticallyCentered(
+                    in: bgRect,
+                    withAttributes: textAttrs)
+                textImage.unlockFocus()
+
+                textImage.draw(
+                    in: bgRect,
+                    from: NSRect.zero,
+                    operation: NSCompositingOperation.destinationOut,
+                    fraction: 1.0)
+            } else {
+                // Inactive: border + direct text, all in black (template handles color)
+                NSColor.black.withAlphaComponent(0.6).setStroke()
+                bgPath.lineWidth = 1.0
+                bgPath.stroke()
+
+                let inactiveAttrs = getStringAttributes(alpha: 0.6, fontSize: 10)
+                spaceText.drawVerticallyCentered(
+                    in: bgRect,
+                    withAttributes: inactiveAttrs)
+            }
+
             iconImage.isTemplate = true
             iconImage.unlockFocus()
 
             newIcons.append(iconImage)
-            index += 1
         }
 
         return newIcons
@@ -177,8 +197,8 @@ class IconCreator {
     }
 
     func mergeIcons(_ iconsWithDisplayProperties: [(image: NSImage, nextSpaceOnDifferentDisplay: Bool)]) -> NSImage {
+        let combinedIconWidth = iconsWithDisplayProperties.reduce(CGFloat.zero) { $0 + $1.image.size.width }
         let numIcons = iconsWithDisplayProperties.count
-        let combinedIconWidth = CGFloat(numIcons) * iconSize.width
         let accomodatingGapWidth = CGFloat(numIcons - 1) * gapWidth
         let accomodatingDisplayGapWidth = CGFloat(displayCount - 1) * displayGapWidth
         let totalWidth = combinedIconWidth + accomodatingGapWidth + accomodatingDisplayGapWidth
@@ -193,9 +213,9 @@ class IconCreator {
                 operation: NSCompositingOperation.sourceOver,
                 fraction: 1.0)
             if icon.nextSpaceOnDifferentDisplay {
-                xOffset += iconSize.width + displayGapWidth
+                xOffset += icon.image.size.width + displayGapWidth
             } else {
-                xOffset += iconSize.width + gapWidth
+                xOffset += icon.image.size.width + gapWidth
             }
         }
         image.isTemplate = true

--- a/Spaceman/Helpers/SpaceObserver.swift
+++ b/Spaceman/Helpers/SpaceObserver.swift
@@ -140,7 +140,7 @@ class SpaceObserver {
         if let pid = spaceInfo["pid"] as? pid_t,
            let app = NSRunningApplication(processIdentifier: pid),
            let name = app.localizedName {
-            return name.prefix(3).uppercased()
+            return name.prefix(10).uppercased()
         }
 
         return "FUL"

--- a/Spaceman/View/PreferencesView.swift
+++ b/Spaceman/View/PreferencesView.swift
@@ -171,10 +171,10 @@ struct PreferencesView: View {
                 }
             }
             TextField(
-                "Name (max 3 char.)",
+                "Name (max 10 char.)",
                 text: Binding(
                     get: {prefsVM.spaceName},
-                    set: {prefsVM.spaceName = $0.prefix(3).trimmingCharacters(in: .whitespacesAndNewlines)}),
+                    set: {prefsVM.spaceName = $0.prefix(10).trimmingCharacters(in: .whitespacesAndNewlines)}),
                 onCommit: updateName)
 
             Button("Update name") {


### PR DESCRIPTION
## Summary

- **Increase space name limit from 3 to 10 characters** in the preferences UI text field
- **Dynamically size menu bar icons** based on text content instead of the fixed 49px width, so longer names display correctly
- **Improve named spaces rendering**: active space gets a filled rounded-rect background with cutout text; inactive spaces get a border with directly drawn text at 60% opacity for much better readability
- Update default fullscreen app name truncation from 3 to 10 characters

## Motivation

The 3-character name limit is quite restrictive — users can't write readable labels like "Slack", "Browser", or "Terminal". This PR raises the limit to 10 characters and makes the rendering adapt to variable-length names.

The contrast improvement addresses poor readability of inactive space names, which were nearly invisible against certain menu bar backgrounds due to the `destinationOut` compositing on thin border icons.

## Changes

| File | Change |
|------|--------|
| `PreferencesView.swift` | `.prefix(3)` → `.prefix(10)`, updated placeholder text |
| `SpaceObserver.swift` | Fullscreen app default name `.prefix(3)` → `.prefix(10)` |
| `IconCreator.swift` | Dynamic icon width calculation, new `createNamedIcons` rendering with filled/bordered styles, variable-width `mergeIcons` layout |

## Screenshots

<img width="923" height="32" alt="image" src="https://github.com/user-attachments/assets/88e5b473-de88-4db4-a9ea-79e0e5de73cf" />


Tested on macOS Tahoe 26.2 with 16 spaces using full-word names (Slack, Monitor, Dev, Browser, etc.)